### PR TITLE
add bsl license header

### DIFF
--- a/pre_commit_hooks/check_licence_header.py
+++ b/pre_commit_hooks/check_licence_header.py
@@ -4,20 +4,14 @@ import argparse
 from typing import Any, Sequence
 
 
-LICENCE_HEADER_TEXT = """// Copyright © 2022 Obol Labs Inc.
+LICENCE_HEADER_TEXT = """// Copyright © 2022-2023 Obol Labs Inc.
 //
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the Free
-// Software Foundation, either version 3 of the License, or (at your option)
-// any later version.
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
 //
-// This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
-//
-// You should have received a copy of the GNU General Public License along with
-// this program.  If not, see <http://www.gnu.org/licenses/>."""
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the GNU General PublicLicense, Version 2.0."""
 
 def prepend_licence_header(filename):
     with open(filename, 'r+') as f:


### PR DESCRIPTION
Adds BUSL 1.1 license header to be added in pre-commit hooks. This BUSL license header is inspired from materialize project: https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/client.rs